### PR TITLE
GC-9709_action_traceability

### DIFF
--- a/lambda_function.js
+++ b/lambda_function.js
@@ -405,7 +405,7 @@ async function handleExecute(body, token) {
                 payload["target_type"] = "space";
             }
             payload["target_id"] = device.id;
-            payload["origin"] = "google";
+            payload["origin"] = "google_assistant";
 
             await helpers
                 .postRequest("/actions", payload, token)

--- a/lambda_function.js
+++ b/lambda_function.js
@@ -405,6 +405,7 @@ async function handleExecute(body, token) {
                 payload["target_type"] = "space";
             }
             payload["target_id"] = device.id;
+            payload["origin"] = "google";
 
             await helpers
                 .postRequest("/actions", payload, token)

--- a/tests/test.js
+++ b/tests/test.js
@@ -40,6 +40,16 @@ describe('Handler tests should pass successfully', () => {
         it('should return successful executions', async () => {
             var resp = await lambda.handleExecute(request.onExecute, null)
             resp.payload.agentUserId = agentUserId
+            let expectedSpaceAction = {
+                "name": 'Google Action Request',
+                "type": "off",
+                "target_type": "space",
+                "target_id": "192837465",
+                "value": {"transition_time": 1},
+                "origin": "google"
+            };
+            expect(rpStub.getCalls()[0].args[0]).to.deep.equal("/actions");
+            expect(rpStub.getCalls()[0].args[1]).to.deep.equal(expectedSpaceAction);
             expect(resp).to.deep.equal(response.onExecute)
         })
     })

--- a/tests/test.js
+++ b/tests/test.js
@@ -46,7 +46,7 @@ describe('Handler tests should pass successfully', () => {
                 "target_type": "space",
                 "target_id": "192837465",
                 "value": {"transition_time": 1},
-                "origin": "google"
+                "origin": "google_assistant"
             };
             expect(rpStub.getCalls()[0].args[0]).to.deep.equal("/actions");
             expect(rpStub.getCalls()[0].args[1]).to.deep.equal(expectedSpaceAction);


### PR DESCRIPTION
Add "origin" field to the Actions coming from the Google Assistant.